### PR TITLE
Updating rmbackup's git check to allow for multiple backups in one repo

### DIFF
--- a/rmbackup/rmbackup
+++ b/rmbackup/rmbackup
@@ -1279,9 +1279,9 @@ if ( $git_commit )
 {
     blueline "Verifying that the backup directory contains a git repo" ;
 
-    if ( ! -d "$out_dir/.git" )
+    if ( 0 != system("cd \"$out_dir\" && git rev-parse --is-inside-work-tree >/dev/null 2>&1") )
     {
-        fail "ERROR: git_commit is true but '$out_dir' is not a git repository" ;
+        fail "ERROR: git_commit is true but '$out_dir' is not part of a git repository" ;
     }
 }
 elsif ( $git_push )


### PR DESCRIPTION
The existing check validates that the repo is in git by directly looking for ` .git` directory.  This fails if the backup directory is _within_ a repo, though.  My expectation is that all of the commands would still work fine if we didn't run this from the root of the repo, though.  

Having the command go in one repo I figured out this command which uses a subshell to validate that the `out_dir` is within a git working tree, seems like a drop-in replacement!

Also, this is my first time seeing your work -- killer stuff.  Thanks for the countless hours working on this stuff and sharing it for free.